### PR TITLE
fix typo in getGuildRoster method

### DIFF
--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -292,7 +292,7 @@ class WowProfileData {
      */
     async getGuildRoster(realmSlug: string, guildName: string): Promise<object> {
         return await this._handleApiCall(
-            `/data/wow/guild/${realmSlug}/${guildName}`,
+            `/data/wow/guild/${realmSlug}/${guildName}/roster`,
             'Error fetching guild roster.'
         );
     }


### PR DESCRIPTION
added `/roster` to URI