### PR TITLE
Support token creation prior to battlenet-api-wrapper class init()

### DIFF
--- a/dist/battleNetWrapper.js
+++ b/dist/battleNetWrapper.js
@@ -62,10 +62,10 @@ class BattleNetWrapper {
                 throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
             if (!clientSecret)
                 throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
-            this.clientId = clientId;
-            this.clientSecret = clientSecret;
             this.origin = origin;
             this.locale = locale;
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
             this.defaultAxiosParams = {
                 locale: this.locale
             };
@@ -76,7 +76,7 @@ class BattleNetWrapper {
                     baseURL: this.originObject[this.origin].hostname,
                     params: this.defaultAxiosParams
                 });
-                yield this._getToken();
+                yield this.setOAuthToken();
                 this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
             }
             catch (error) {
@@ -93,10 +93,10 @@ class BattleNetWrapper {
             this.WowClassicGameData = new gameData_5.default(this.axios, this.defaultAxiosParams, this.origin);
         });
     }
-    // Gets a new access token for all of the subsequent API requests.
-    // Every invocation of this class will create a new access token,
+    // Sets a new access token for all of the subsequent API requests.
+    // Every invocation of this method will create a new access token,
     // so you should never have to worry about the token ever expiring.
-    _getToken() {
+    setOAuthToken() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 const response = yield axios_1.default.get(`https://${this.origin}.battle.net/oauth/token`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "battlenet-api-wrapper",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/battleNetWrapper.ts
+++ b/src/battleNetWrapper.ts
@@ -64,18 +64,21 @@ class BattleNetWrapper {
     // and await all of the underlying promises.
     constructor() {}
 
-    async init(clientId: string, clientSecret: string, origin: string = 'us', locale: string = 'en_US') {
-        if (!clientId) throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
-        if (!clientSecret) throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
-
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
+    async init(clientId: string, clientSecret: string, providedToken?: string, origin: string = 'us', locale: string = 'en_US') {
         this.origin = origin;
         this.locale = locale;
 
         this.defaultAxiosParams = {
             locale: this.locale
         };
+
+        if (!providedToken) {
+            if (!clientId) throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
+            if (!clientSecret) throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
+
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+        }
 
         // Handles the fetching of a new OAuth token from the Battle.net API
         // and then creates a reusable instance of axios for all subsequent API requests.
@@ -85,8 +88,12 @@ class BattleNetWrapper {
                 params: this.defaultAxiosParams
             });
 
-            await this._getToken();
-            this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
+            if (providedToken) {
+                this.axios.defaults.headers.common['Authorization'] = `Bearer ${providedToken}`;
+            } else {
+                await this.getToken();
+                this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
+            }
         } catch (error) {
             console.log(error);
         }
@@ -105,12 +112,12 @@ class BattleNetWrapper {
     // Gets a new access token for all of the subsequent API requests.
     // Every invocation of this class will create a new access token,
     // so you should never have to worry about the token ever expiring.
-    async _getToken() {
+    async getToken(clientId?: string, clientSecret?: string, origin?: string) {
         try {
-            const response = await axios.get(`https://${this.origin}.battle.net/oauth/token`, {
+            const response = await axios.get(`https://${(origin) ? origin : this.origin}.battle.net/oauth/token`, {
                 auth: {
-                    username: this.clientId,
-                    password: this.clientSecret,
+                    username: (clientId) ? clientId : this.clientId,
+                    password: (clientSecret) ? clientSecret : this.clientSecret,
                 },
                 params: {
                     grant_type: 'client_credentials',

--- a/src/battleNetWrapper.ts
+++ b/src/battleNetWrapper.ts
@@ -64,21 +64,18 @@ class BattleNetWrapper {
     // and await all of the underlying promises.
     constructor() {}
 
-    async init(clientId: string, clientSecret: string, providedToken?: string, origin: string = 'us', locale: string = 'en_US') {
+    async init(clientId: string, clientSecret: string, origin: string = 'us', locale: string = 'en_US') {
+        if (!clientId) throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
+        if (!clientSecret) throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
+
         this.origin = origin;
         this.locale = locale;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
 
         this.defaultAxiosParams = {
             locale: this.locale
         };
-
-        if (!providedToken) {
-            if (!clientId) throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
-            if (!clientSecret) throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
-
-            this.clientId = clientId;
-            this.clientSecret = clientSecret;
-        }
 
         // Handles the fetching of a new OAuth token from the Battle.net API
         // and then creates a reusable instance of axios for all subsequent API requests.
@@ -88,12 +85,8 @@ class BattleNetWrapper {
                 params: this.defaultAxiosParams
             });
 
-            if (providedToken) {
-                this.axios.defaults.headers.common['Authorization'] = `Bearer ${providedToken}`;
-            } else {
-                await this.getToken();
-                this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
-            }
+            await this.setOAuthToken();
+            this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
         } catch (error) {
             console.log(error);
         }
@@ -109,15 +102,15 @@ class BattleNetWrapper {
         this.WowClassicGameData = new WowClassicGameData(this.axios, this.defaultAxiosParams, this.origin);
     }
 
-    // Gets a new access token for all of the subsequent API requests.
-    // Every invocation of this class will create a new access token,
+    // Sets a new access token for all of the subsequent API requests.
+    // Every invocation of this method will create a new access token,
     // so you should never have to worry about the token ever expiring.
-    async getToken(clientId?: string, clientSecret?: string, origin?: string) {
+    async setOAuthToken() {
         try {
-            const response = await axios.get(`https://${(origin) ? origin : this.origin}.battle.net/oauth/token`, {
+            const response = await axios.get(`https://${this.origin}.battle.net/oauth/token`, {
                 auth: {
-                    username: (clientId) ? clientId : this.clientId,
-                    password: (clientSecret) ? clientSecret : this.clientSecret,
+                    username: this.clientId,
+                    password: this.clientSecret,
                 },
                 params: {
                     grant_type: 'client_credentials',


### PR DESCRIPTION
This change stems from this issue: https://github.com/QuadDamn/battlenet-api-wrapper/issues/18

The change will allow for you to instantiate the class and then call the getToken method to set the `oauthToken` within the class.  If you need to refresh the token after the `init()` method has been called, you can simply call `getToken` method again and it will refresh the token within the instantiated class.