### PR TITLE
Missing timeout for requests

### DIFF
--- a/src/battleNetWrapper.ts
+++ b/src/battleNetWrapper.ts
@@ -82,6 +82,7 @@ class BattleNetWrapper {
         try {
             this.axios = axios.create({
                 baseURL: this.originObject[this.origin].hostname,
+                timeout: 10000,
                 params: this.defaultAxiosParams
             });
 


### PR DESCRIPTION
The problem is that default `AxiosInstance` param have endless (0) timeout for all requests.

It means that, if Blizzard API goes down or the response will be somehow missing, without proper answer from server-side you request will never end. It could become a problem is you are using `Promise.all([request1(), request2()])` or `for await (promise of promises)` which will stop the whole thread,

So, this one string will help everyone to solve this problem.

This PR doesn't have a compiled `*.js` version of code. so after accepting PR and it's merge it should be compiled by Travis/etc