### PR TITLE
Account Profile API support

### DIFF
--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -18,6 +18,80 @@ class WowProfileData {
         this.namespace = `profile-${origin}`;
     }
     /**
+     * Returns a profile summary for an account.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *`
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    getAccountProfile(accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleAccessTokenApiCall(`/profile/user/wow`, 'Error fetching account summary.', accessToken);
+        });
+    }
+    /**
+     * Returns a protected profile summary for a character.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *`
+     * @param realmId The ID of the character's realm.
+     * @param characterId The ID of the character.
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    getProtectedCharacterSummary(realmId, characterId, accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleAccessTokenApiCall(`/profile/user/wow/protected-character/${realmId}-${characterId}`, 'Error fetching protected character summary.', accessToken);
+        });
+    }
+    /**
+     * Returns an index of collection types for an account.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    getAccountCollectionsIndex(accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleAccessTokenApiCall(`/profile/user/wow/collections`, 'Error fetching account collections.', accessToken);
+        });
+    }
+    /**
+     *
+     * Returns a summary of the mounts an account has obtained.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    getAccountMountsCollectionSummary(accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleAccessTokenApiCall(`/profile/user/wow/collections/mounts`, 'Error fetching account mount collections.', accessToken);
+        });
+    }
+    /**
+ *
+ * Returns a summary of the battle pets an account has obtained.
+ *
+ * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+ *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+ *
+ * @param accessToken The access token of the user requesting the profile information
+ *
+ */
+    getAccountPetsCollectionSummary(accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleAccessTokenApiCall(`/profile/user/wow/collections/pets`, 'Error fetching account mount collections.', accessToken);
+        });
+    }
+    /**
      * Returns a summary of the achievements a character has completed.
      *
      * @param realmSlug The slug of the realm.
@@ -268,6 +342,23 @@ class WowProfileData {
             try {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
                     params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams)
+                });
+                return response.data;
+            }
+            catch (error) {
+                console.log(error);
+                throw new Error(`WoW Profile Error :: ${errorMessage}`);
+            }
+        });
+    }
+    _handleAccessTokenApiCall(apiUrl, errorMessage, accessToken) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const response = yield this.axios.get(encodeURI(apiUrl), {
+                    params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams),
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`
+                    }
                 });
                 return response.data;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battlenet-api-wrapper",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A promised-based Node.js wrapper for the Battle.net Community and Data APIs (supports WoW, WoW Classic, SC2, D3, and Hearthstone).",
   "main": "index.js",
   "scripts": {

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -15,6 +15,95 @@ class WowProfileData {
     }
 
     /**
+     * Returns a profile summary for an account.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *`
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    async getAccountProfile(accessToken: string) : Promise<object> {
+        return await this._handleAccessTokenApiCall(
+            `/profile/user/wow`,
+            'Error fetching account summary.',
+            accessToken
+        );
+    }
+
+    /**
+     * Returns a protected profile summary for a character.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *`
+     * @param realmId The ID of the character's realm.
+     * @param characterId The ID of the character.
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    async getProtectedCharacterSummary(realmId: number, characterId: number, accessToken: string) : Promise<object> {
+        return await this._handleAccessTokenApiCall(
+            `/profile/user/wow/protected-character/${realmId}-${characterId}`,
+            'Error fetching protected character summary.',
+            accessToken
+        );
+    }
+
+    /**
+     * Returns an index of collection types for an account.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    async getAccountCollectionsIndex(accessToken: string) : Promise<object> {
+        return await this._handleAccessTokenApiCall(
+            `/profile/user/wow/collections`,
+            'Error fetching account collections.',
+            accessToken
+        );
+    }
+
+    /**
+     *
+     * Returns a summary of the mounts an account has obtained.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    async getAccountMountsCollectionSummary(accessToken: string) : Promise<object> {
+        return await this._handleAccessTokenApiCall(
+            `/profile/user/wow/collections/mounts`,
+            'Error fetching account mount collections.',
+            accessToken
+        );
+    }
+
+        /**
+     *
+     * Returns a summary of the battle pets an account has obtained.
+     *
+     * Because this endpoint provides data about the current logged-in user's World of Warcraft account,
+     *  it requires an access token with the wow.profile scope acquired via the Authorization Code Flow.
+     *
+     * @param accessToken The access token of the user requesting the profile information
+     *
+     */
+    async getAccountPetsCollectionSummary(accessToken: string) : Promise<object> {
+        return await this._handleAccessTokenApiCall(
+            `/profile/user/wow/collections/pets`,
+            'Error fetching account mount collections.',
+            accessToken
+        );
+    }
+
+    /**
      * Returns a summary of the achievements a character has completed.
      *
      * @param realmSlug The slug of the realm.
@@ -307,6 +396,23 @@ class WowProfileData {
                 params: {
                     namespace: this.namespace,
                     ...this.defaultAxiosParams
+                }});
+            return response.data;
+        } catch (error) {
+            console.log(error);
+            throw new Error(`WoW Profile Error :: ${errorMessage}`);
+        }
+    }
+
+    async _handleAccessTokenApiCall(apiUrl: string, errorMessage: string, accessToken: string) : Promise<object> {
+        try {
+            const response = await this.axios.get(encodeURI(apiUrl), {
+                params: {
+                    namespace: this.namespace,
+                    ...this.defaultAxiosParams
+                },
+                headers: {
+                    Authorization: `Bearer ${accessToken}`
                 }});
             return response.data;
         } catch (error) {


### PR DESCRIPTION
I added support for calling the account profile API.  

Each of the methods includes an `accessToken` parameter that is the individual token of the user making the call.  This token overrides the default Bearer token of the application that is acquired on the `init` of the `BattleNetWrapper` class.