### PR TITLE
Professions, Recipe and AuctionHouse endpoints

### DIFF
--- a/dist/battleNetWrapper.js
+++ b/dist/battleNetWrapper.js
@@ -61,7 +61,8 @@ class BattleNetWrapper {
             this.origin = origin;
             this.locale = locale;
             this.defaultAxiosParams = {
-                locale: this.locale
+                locale: this.locale,
+                timeout: 10000
             };
             if (!providedToken) {
                 if (!clientId)

--- a/dist/battleNetWrapper.js
+++ b/dist/battleNetWrapper.js
@@ -56,19 +56,21 @@ class BattleNetWrapper {
             }
         };
     }
-    init(clientId, clientSecret, origin = 'us', locale = 'en_US') {
+    init(clientId, clientSecret, providedToken, origin = 'us', locale = 'en_US') {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!clientId)
-                throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
-            if (!clientSecret)
-                throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
             this.origin = origin;
             this.locale = locale;
-            this.clientId = clientId;
-            this.clientSecret = clientSecret;
             this.defaultAxiosParams = {
                 locale: this.locale
             };
+            if (!providedToken) {
+                if (!clientId)
+                    throw new Error('You are missing your Client ID in the passed parameters. This parameter is required.');
+                if (!clientSecret)
+                    throw new Error('You are missing your Client Secret in the passed parameters. This parameter is required.');
+                this.clientId = clientId;
+                this.clientSecret = clientSecret;
+            }
             // Handles the fetching of a new OAuth token from the Battle.net API
             // and then creates a reusable instance of axios for all subsequent API requests.
             try {
@@ -76,8 +78,13 @@ class BattleNetWrapper {
                     baseURL: this.originObject[this.origin].hostname,
                     params: this.defaultAxiosParams
                 });
-                yield this.setOAuthToken();
-                this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
+                if (providedToken) {
+                    this.axios.defaults.headers.common['Authorization'] = `Bearer ${providedToken}`;
+                }
+                else {
+                    yield this.getToken();
+                    this.axios.defaults.headers.common['Authorization'] = `Bearer ${this.oauthToken}`;
+                }
             }
             catch (error) {
                 console.log(error);
@@ -93,16 +100,16 @@ class BattleNetWrapper {
             this.WowClassicGameData = new gameData_5.default(this.axios, this.defaultAxiosParams, this.origin);
         });
     }
-    // Sets a new access token for all of the subsequent API requests.
-    // Every invocation of this method will create a new access token,
+    // Gets a new access token for all of the subsequent API requests.
+    // Every invocation of this class will create a new access token,
     // so you should never have to worry about the token ever expiring.
-    setOAuthToken() {
+    getToken(clientId, clientSecret, origin) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const response = yield axios_1.default.get(`https://${this.origin}.battle.net/oauth/token`, {
+                const response = yield axios_1.default.get(`https://${(origin) ? origin : this.origin}.battle.net/oauth/token`, {
                     auth: {
-                        username: this.clientId,
-                        password: this.clientSecret,
+                        username: (clientId) ? clientId : this.clientId,
+                        password: (clientSecret) ? clientSecret : this.clientSecret,
                     },
                     params: {
                         grant_type: 'client_credentials',

--- a/dist/battleNetWrapper.js
+++ b/dist/battleNetWrapper.js
@@ -77,6 +77,7 @@ class BattleNetWrapper {
             try {
                 this.axios = axios_1.default.create({
                     baseURL: this.originObject[this.origin].hostname,
+                    timeout: 10000,
                     params: this.defaultAxiosParams
                 });
                 if (providedToken) {

--- a/dist/battleNetWrapper.js
+++ b/dist/battleNetWrapper.js
@@ -62,7 +62,6 @@ class BattleNetWrapper {
             this.locale = locale;
             this.defaultAxiosParams = {
                 locale: this.locale,
-                timeout: 10000
             };
             if (!providedToken) {
                 if (!clientId)

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,7 +778,14 @@ class WowGameData {
                 }
             }
             catch (error) {
-                if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+                console.log(typeof error.response.status);
+                if (error.response.status == 304) {
+                }
+                else if (error.response.status == 404) {
+                }
+                else if (error.response.status == 403) {
+                }
+                else {
                     console.error(error.response.statusText);
                 }
                 throw new Error(`${errorMessage}`);

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,13 +778,13 @@ class WowGameData {
             }
             catch (error) {
                 if (error.response.status === 304) {
-                    return error.response.status;
+                    throw new Error(error.response.status);
                 }
                 else if (error.response.status === 404) {
-                    return error.response.status;
+                    throw new Error(error.response.status);
                 }
                 else if (error.response.status === 403) {
-                    return error.response.status;
+                    throw new Error(error.response.status);
                 }
                 else {
                     console.error(error.response.statusText);

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -780,7 +780,7 @@ class WowGameData {
             catch (error) {
                 if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403)
                     console.log(error.response.statusText);
-                throw new Error(`WoW Game Data Error :: ${errorMessage}`);
+                throw new Error(`${errorMessage}`);
             }
         });
     }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -761,7 +761,7 @@ class WowGameData {
                     params: Object.assign({ namespace: namespace }, this.defaultAxiosParams)
                 });
                 if (apiUrl.includes("auctions")) {
-                    return { auctions: response.data.auctions, lastModified: response.headers };
+                    return { auctions: response.data.auctions, lastModified: response.headers['last-modified'] };
                 }
                 else {
                     return response.data;

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -776,10 +776,13 @@ class WowGameData {
             }
             catch (error) {
                 if (error.response.status === 304) {
+                    return error.response.status;
                 }
                 else if (error.response.status === 404) {
+                    return error.response.status;
                 }
                 else if (error.response.status === 403) {
+                    return error.response.status;
                 }
                 else {
                     console.error(error.response.statusText);

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -779,7 +779,7 @@ class WowGameData {
             }
             catch (error) {
                 console.log(`WoW Game Data Error :: ${errorMessage}`);
-                throw new Error(error);
+                return error;
             }
         });
     }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,8 +778,8 @@ class WowGameData {
                 }
             }
             catch (error) {
-                console.log(error);
-                throw new Error(`WoW Game Data Error :: ${errorMessage}`);
+                console.log(`WoW Game Data Error :: ${errorMessage}`);
+                throw new Error(error);
             }
         });
     }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -78,7 +78,7 @@ class WowGameData {
      */
     getAuctionHouse(connectedRealmId, header = '') {
         return __awaiter(this, void 0, void 0, function* () {
-            return yield this._handleApiCall(`${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`, 'Error fetching auction house data.', this.dynamicNamespace, header);
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`, `Error fetching auction house data from ${connectedRealmId}`, this.dynamicNamespace, header);
         });
     }
     /****************************

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,12 +778,8 @@ class WowGameData {
                 }
             }
             catch (error) {
-                if (error.response.status === 304)
-                    return error.response.statusText;
-                if (error.response.status === 404)
-                    return error.response.statusText;
-                if (error.response.status === 403)
-                    return error.response.statusText;
+                if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403)
+                    console.log(error.response.statusText);
                 throw new Error(`WoW Game Data Error :: ${errorMessage}`);
             }
         });

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -557,6 +557,57 @@ class WowGameData {
         });
     }
     /****************************
+     * Professions API
+     ****************************/
+    /**
+     * Returns an index of professions.
+     */
+    getProfessionsIndex() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/profession/index`, 'Error fetching professions index.', this.staticNamespace);
+        });
+    }
+    /**
+     * Returns a profession by ID
+     */
+    getProfession(professionId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/profession/${professionId}`, 'Error fetching professions.', this.staticNamespace);
+        });
+    }
+    /**
+     * Returns media for a profession by ID.
+     */
+    getProfessionMedia(professionId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/media/profession/${professionId}`, 'Error fetching specified profession media.', this.staticNamespace);
+        });
+    }
+    /**
+     * Returns a skill tier for a profession by ID.
+     */
+    getProfessionSkillTier(professionId, skillTierId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/profession/${professionId}/skill-tier/${skillTierId}`, 'Error fetching skill tier profession.', this.staticNamespace);
+        });
+    }
+    /**
+     * Returns a recipe by ID.
+     */
+    getRecipe(recipeId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/recipe/${recipeId} `, 'Error fetching recipe by ID.', this.staticNamespace);
+        });
+    }
+    /**
+     * Returns media for a recipe by ID.
+     */
+    getRecipeMedia(recipeId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/media/recipe/${recipeId}`, 'Error fetching recipe media by ID.', this.staticNamespace);
+        });
+    }
+    /****************************
      * PvP Season API
      ****************************/
     /**

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -68,6 +68,19 @@ class WowGameData {
         });
     }
     /****************************
+     * Auction House API
+     ****************************/
+    /**
+     * Returns all active auctions for a connected realm.
+     *
+     * @param achievementId The ID of the achievement.
+     */
+    getAuctionHouse(connectedRealmId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`, 'Error fetching auction house data.', this.staticNamespace);
+        });
+    }
+    /****************************
      * Azerite Essence API
      ****************************/
     /**

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -769,6 +769,8 @@ class WowGameData {
                         params: Object.assign({ namespace: namespace }, this.defaultAxiosParams),
                         headers: { 'If-Modified-Since': header },
                     });
+                    if (response.data['statusCode'])
+                        response.data.statusCode = response.status;
                     if (response.headers['last-modified'])
                         response.data.lastModified = response.headers['last-modified'];
                     return response.data;

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -779,7 +779,7 @@ class WowGameData {
             }
             catch (error) {
                 console.error(`WoW Game Data Error :: ${errorMessage}`);
-                console.log(error.statusCode);
+                console.log(error);
                 //throw new Error(error)
             }
         });

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -786,6 +786,9 @@ class WowGameData {
                 else if (error.response.status === 403) {
                     throw new Error(error.response.status);
                 }
+                else if (error.response.status === 500) {
+                    throw new Error(error.response.status);
+                }
                 else {
                     console.error(error.response.statusText);
                 }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -77,7 +77,7 @@ class WowGameData {
      */
     getAuctionHouse(connectedRealmId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return yield this._handleApiCall(`${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`, 'Error fetching auction house data.', this.staticNamespace);
+            return yield this._handleApiCall(`${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`, 'Error fetching auction house data.', this.dynamicNamespace);
         });
     }
     /****************************

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,8 +778,9 @@ class WowGameData {
                 }
             }
             catch (error) {
-                console.log(`WoW Game Data Error :: ${errorMessage}`);
-                return error;
+                console.error(`WoW Game Data Error :: ${errorMessage}`);
+                console.log(error.statusCode);
+                //throw new Error(error)
             }
         });
     }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -73,7 +73,7 @@ class WowGameData {
     /**
      * Returns all active auctions for a connected realm.
      *
-     * @param achievementId The ID of the achievement.
+     * @param connectedRealmId The ID of the connected realm.
      */
     getAuctionHouse(connectedRealmId) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,8 +778,9 @@ class WowGameData {
                 }
             }
             catch (error) {
-                if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403)
-                    console.log(error.response.statusText);
+                if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+                    console.error(error.response.statusText);
+                }
                 throw new Error(`${errorMessage}`);
             }
         });

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -760,7 +760,12 @@ class WowGameData {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
                     params: Object.assign({ namespace: namespace }, this.defaultAxiosParams)
                 });
-                return response.data;
+                if (apiUrl.includes("auctions")) {
+                    return { auctions: response.data.auctions, lastModified: response.headers };
+                }
+                else {
+                    return response.data;
+                }
             }
             catch (error) {
                 console.log(error);

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -76,7 +76,7 @@ class WowGameData {
      * @param connectedRealmId The ID of the connected realm.
      * @param header If-Modified-Since request HTTP header
      */
-    getAuctionHouse(connectedRealmId, header) {
+    getAuctionHouse(connectedRealmId, header = '') {
         return __awaiter(this, void 0, void 0, function* () {
             return yield this._handleApiCall(`${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`, 'Error fetching auction house data.', this.dynamicNamespace, header);
         });

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -760,13 +760,13 @@ class WowGameData {
             try {
                 if (namespace.includes("static-")) {
                     const response = yield this.axios.get(encodeURI(apiUrl), {
-                        params: Object.assign({ namespace: namespace }, this.defaultAxiosParams),
+                        params: Object.assign({ timeout: 10000, namespace: namespace }, this.defaultAxiosParams),
                     });
                     return response.data;
                 }
                 else {
                     const response = yield this.axios.get(encodeURI(apiUrl), {
-                        params: Object.assign({ namespace: namespace }, this.defaultAxiosParams),
+                        params: Object.assign({ timeout: 10000, namespace: namespace }, this.defaultAxiosParams),
                         headers: { 'If-Modified-Since': header },
                     });
                     if (response.status)

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -760,7 +760,7 @@ class WowGameData {
             try {
                 if (namespace.includes("static-")) {
                     const response = yield this.axios.get(encodeURI(apiUrl), {
-                        params: Object.assign({ timeout: 10000, namespace: namespace }, this.defaultAxiosParams),
+                        params: Object.assign({ namespace: namespace }, this.defaultAxiosParams),
                     });
                     return response.data;
                 }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -779,8 +779,12 @@ class WowGameData {
             }
             catch (error) {
                 console.error(`WoW Game Data Error :: ${errorMessage}`);
-                console.log(error.response);
-                //throw new Error(error)
+                if (error.response.status === 304)
+                    return error.response.statusText;
+                if (error.response.status === 404)
+                    return error.response.statusText;
+                if (error.response.status === 403)
+                    return error.response.statusText;
             }
         });
     }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -773,6 +773,8 @@ class WowGameData {
                         return { auctions: response.data.auctions, lastModified: response.headers['last-modified'] };
                     }
                     else {
+                        if (response.headers['last-modified'])
+                            response.data.lastModified = response.headers['last-modified'];
                         return response.data;
                     }
                 }

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -769,14 +769,9 @@ class WowGameData {
                         params: Object.assign({ namespace: namespace }, this.defaultAxiosParams),
                         headers: { 'If-Modified-Since': header },
                     });
-                    if (apiUrl.includes("auctions")) {
-                        return { auctions: response.data.auctions, lastModified: response.headers['last-modified'] };
-                    }
-                    else {
-                        if (response.headers['last-modified'])
-                            response.data.lastModified = response.headers['last-modified'];
-                        return response.data;
-                    }
+                    if (response.headers['last-modified'])
+                        response.data.lastModified = response.headers['last-modified'];
+                    return response.data;
                 }
             }
             catch (error) {

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,12 +778,11 @@ class WowGameData {
                 }
             }
             catch (error) {
-                console.log(typeof error.response.status);
-                if (error.response.status == 304) {
+                if (error.response.status === 304) {
                 }
-                else if (error.response.status == 404) {
+                else if (error.response.status === 404) {
                 }
-                else if (error.response.status == 403) {
+                else if (error.response.status === 403) {
                 }
                 else {
                     console.error(error.response.statusText);

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -769,7 +769,7 @@ class WowGameData {
                         params: Object.assign({ namespace: namespace }, this.defaultAxiosParams),
                         headers: { 'If-Modified-Since': header },
                     });
-                    if (response.data['statusCode'])
+                    if (response.status)
                         response.data.statusCode = response.status;
                     if (response.headers['last-modified'])
                         response.data.lastModified = response.headers['last-modified'];

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -777,16 +777,7 @@ class WowGameData {
                 }
             }
             catch (error) {
-                if (error.response.status === 304) {
-                    throw new Error(error.response.status);
-                }
-                else if (error.response.status === 404) {
-                    throw new Error(error.response.status);
-                }
-                else if (error.response.status === 403) {
-                    throw new Error(error.response.status);
-                }
-                else if (error.response.status === 500) {
+                if (~[304, 404, 403, 500].indexOf(error.response.status)) {
                     throw new Error(error.response.status);
                 }
                 else {

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -779,7 +779,7 @@ class WowGameData {
             }
             catch (error) {
                 console.error(`WoW Game Data Error :: ${errorMessage}`);
-                console.log(error);
+                console.log(error.response);
                 //throw new Error(error)
             }
         });

--- a/dist/wow/gameData.js
+++ b/dist/wow/gameData.js
@@ -778,13 +778,13 @@ class WowGameData {
                 }
             }
             catch (error) {
-                console.error(`WoW Game Data Error :: ${errorMessage}`);
                 if (error.response.status === 304)
                     return error.response.statusText;
                 if (error.response.status === 404)
                     return error.response.statusText;
                 if (error.response.status === 403)
                     return error.response.statusText;
+                throw new Error(`WoW Game Data Error :: ${errorMessage}`);
             }
         });
     }

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -269,6 +269,8 @@ class WowProfileData {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
                     params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams)
                 });
+                if (response.headers['last-modified'])
+                    response.data.lastModified = response.headers['last-modified'];
                 return response.data;
             }
             catch (error) {

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -269,6 +269,8 @@ class WowProfileData {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
                     params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams)
                 });
+                if (response.data['statusCode'])
+                    response.data.statusCode = response.status;
                 if (response.headers['last-modified'])
                     response.data.lastModified = response.headers['last-modified'];
                 return response.data;

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -272,12 +272,11 @@ class WowProfileData {
                 return response.data;
             }
             catch (error) {
-                console.log(typeof error.response.status);
-                if (error.response.status == 304) {
+                if (error.response.status === 304) {
                 }
-                else if (error.response.status == 404) {
+                else if (error.response.status === 404) {
                 }
-                else if (error.response.status == 403) {
+                else if (error.response.status === 403) {
                 }
                 else {
                     console.error(error.response.statusText);

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -269,7 +269,7 @@ class WowProfileData {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
                     params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams)
                 });
-                if (response.data['statusCode'])
+                if (response.status)
                     response.data.statusCode = response.status;
                 if (response.headers['last-modified'])
                     response.data.lastModified = response.headers['last-modified'];

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -272,11 +272,7 @@ class WowProfileData {
                 return response.data;
             }
             catch (error) {
-                if (error.response.status === 304)
-                    console.log(error.response.statusText);
-                if (error.response.status === 404)
-                    console.log(error.response.statusText);
-                if (error.response.status === 403)
+                if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403)
                     console.log(error.response.statusText);
                 throw new Error(`WoW Game Data Error :: ${errorMessage}`);
             }

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -267,7 +267,7 @@ class WowProfileData {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
-                    params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams)
+                    params: Object.assign({ timeout: 10000, namespace: this.namespace }, this.defaultAxiosParams)
                 });
                 if (response.status)
                     response.data.statusCode = response.status;

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -276,16 +276,7 @@ class WowProfileData {
                 return response.data;
             }
             catch (error) {
-                if (error.response.status === 304) {
-                    throw new Error(error.response.status);
-                }
-                else if (error.response.status === 404) {
-                    throw new Error(error.response.status);
-                }
-                else if (error.response.status === 403) {
-                    throw new Error(error.response.status);
-                }
-                else if (error.response.status === 500) {
+                if (~[304, 404, 403, 500].indexOf(error.response.status)) {
                     throw new Error(error.response.status);
                 }
                 else {

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -274,7 +274,7 @@ class WowProfileData {
             catch (error) {
                 if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403)
                     console.log(error.response.statusText);
-                throw new Error(`WoW Game Data Error :: ${errorMessage}`);
+                throw new Error(`${errorMessage}`);
             }
         });
     }

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -285,6 +285,9 @@ class WowProfileData {
                 else if (error.response.status === 403) {
                     throw new Error(error.response.status);
                 }
+                else if (error.response.status === 500) {
+                    throw new Error(error.response.status);
+                }
                 else {
                     console.error(error.response.statusText);
                 }

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -275,10 +275,13 @@ class WowProfileData {
             }
             catch (error) {
                 if (error.response.status === 304) {
+                    return error.response.status;
                 }
                 else if (error.response.status === 404) {
+                    return error.response.status;
                 }
                 else if (error.response.status === 403) {
+                    return error.response.status;
                 }
                 else {
                     console.error(error.response.statusText);

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -272,8 +272,9 @@ class WowProfileData {
                 return response.data;
             }
             catch (error) {
-                if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403)
-                    console.log(error.response.statusText);
+                if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+                    console.error(error.response.statusText);
+                }
                 throw new Error(`${errorMessage}`);
             }
         });

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -272,8 +272,13 @@ class WowProfileData {
                 return response.data;
             }
             catch (error) {
-                console.log(error);
-                throw new Error(`WoW Profile Error :: ${errorMessage}`);
+                if (error.response.status === 304)
+                    console.log(error.response.statusText);
+                if (error.response.status === 404)
+                    console.log(error.response.statusText);
+                if (error.response.status === 403)
+                    console.log(error.response.statusText);
+                throw new Error(`WoW Game Data Error :: ${errorMessage}`);
             }
         });
     }

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -272,7 +272,14 @@ class WowProfileData {
                 return response.data;
             }
             catch (error) {
-                if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+                console.log(typeof error.response.status);
+                if (error.response.status == 304) {
+                }
+                else if (error.response.status == 404) {
+                }
+                else if (error.response.status == 403) {
+                }
+                else {
                     console.error(error.response.statusText);
                 }
                 throw new Error(`${errorMessage}`);

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -267,7 +267,7 @@ class WowProfileData {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 const response = yield this.axios.get(encodeURI(apiUrl), {
-                    params: Object.assign({ timeout: 10000, namespace: this.namespace }, this.defaultAxiosParams)
+                    params: Object.assign({ namespace: this.namespace }, this.defaultAxiosParams)
                 });
                 if (response.status)
                     response.data.statusCode = response.status;

--- a/dist/wow/profileData.js
+++ b/dist/wow/profileData.js
@@ -277,13 +277,13 @@ class WowProfileData {
             }
             catch (error) {
                 if (error.response.status === 304) {
-                    return error.response.status;
+                    throw new Error(error.response.status);
                 }
                 else if (error.response.status === 404) {
-                    return error.response.status;
+                    throw new Error(error.response.status);
                 }
                 else if (error.response.status === 403) {
-                    return error.response.status;
+                    throw new Error(error.response.status);
                 }
                 else {
                     console.error(error.response.statusText);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^3.7.4"
   },
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.19.2",
     "jest": "^25.1.0"
   },
   "jest": {

--- a/src/battleNetWrapper.ts
+++ b/src/battleNetWrapper.ts
@@ -69,7 +69,8 @@ class BattleNetWrapper {
         this.locale = locale;
 
         this.defaultAxiosParams = {
-            locale: this.locale
+            locale: this.locale,
+            timeout: 10000
         };
 
         if (!providedToken) {

--- a/src/battleNetWrapper.ts
+++ b/src/battleNetWrapper.ts
@@ -86,6 +86,7 @@ class BattleNetWrapper {
         try {
             this.axios = axios.create({
                 baseURL: this.originObject[this.origin].hostname,
+                timeout: 10000,
                 params: this.defaultAxiosParams
             });
 

--- a/src/battleNetWrapper.ts
+++ b/src/battleNetWrapper.ts
@@ -70,7 +70,6 @@ class BattleNetWrapper {
 
         this.defaultAxiosParams = {
             locale: this.locale,
-            timeout: 10000
         };
 
         if (!providedToken) {

--- a/src/wow/README.md
+++ b/src/wow/README.md
@@ -458,6 +458,16 @@ Returns media for an achievement by ID.
 -   `achievementId` **[number][312]** The ID of the achievement.  
   
 Returns **[Promise][310]&lt;[object][311]>**   
+
+### getAuctionHouse  
+  
+Returns all active auctions for a connected realm.
+  
+#### Parameters  
+  
+- `connectedRealmId` **[number][312]** The ID of the connected realm.  
+  
+Returns **[Promise][310]&lt;[object][311]>**   
   
 ### getAzeriteEssenceIndex  
   

--- a/src/wow/README.md
+++ b/src/wow/README.md
@@ -470,12 +470,13 @@ Returns **[Promise][310]&lt;[object][311]>**
 
 ### getAuctionHouse  
   
-Returns all active auctions for a connected realm.
+Returns all active auctions for a connected realm. If header (*optional*, format: `ddd, DD MMM YYYY HH:mm:ss GMT`) is used, returns all auctions since lastModified date.
   
 #### Parameters  
   
 - `connectedRealmId` **[number][312]** The ID of the connected realm.  
-  
+- `header` **[string][313]** (optional) If-Modified-Since request HTTP header
+
 Returns **[Promise][310]&lt;[object][311]>**   
   
 ### getAzeriteEssenceIndex  

--- a/src/wow/README.md
+++ b/src/wow/README.md
@@ -356,6 +356,7 @@ const clientSecret = 'YOUR_CLIENT_SECRET';
 -   [getAzeriteEssenceIndex][128]  
 -   [getAzeriteEssence][129]  
 -   [getAzeriteEssenceMedia][131]    
+-   [getAuctionHouse][132]  
 -   [getConnectedRealmsIndex][133]  
 -   [getConnectedRealm][134]  
 -   [getCreatureFamiliesIndex][136]  

--- a/src/wow/README.md
+++ b/src/wow/README.md
@@ -356,7 +356,7 @@ const clientSecret = 'YOUR_CLIENT_SECRET';
 -   [getAzeriteEssenceIndex][128]  
 -   [getAzeriteEssence][129]  
 -   [getAzeriteEssenceMedia][131]    
--   [getAuctionHouse][132]  
+-   [getAuctionHouse][316]  
 -   [getConnectedRealmsIndex][133]  
 -   [getConnectedRealm][134]  
 -   [getCreatureFamiliesIndex][136]  
@@ -400,6 +400,12 @@ const clientSecret = 'YOUR_CLIENT_SECRET';
 -   [getPlayableSpecialization][198]  
 -   [getPowerTypesIndex][200]  
 -   [getPowerType][201]  
+-   [getProfessionIndex][315]  
+-   [getProfession][317]  
+-   [getProfessionMedia][318]  
+-   [getProfessionSkillTier][319]  
+-   [getRecipe][320]  
+-   [getRecipeMedia][321]  
 -   [getPvpSeasonsIndex][203]  
 -   [getPvpSeason][204]  
 -   [getPvpLeaderboardsIndex][206]  
@@ -867,6 +873,63 @@ Returns a power type by ID.
 -   `powerTypeId` **[number][312]**   
   
 Returns **[Promise][310]&lt;[object][311]>**   
+ 
+### getProfessionIndex  
+  
+Returns an index of professions.
+  
+Returns **[Promise][310]&lt;[object][311]>**
+
+### getProfession  
+  
+Returns a profession by ID.
+  
+#### Parameters  
+  
+-   `professionId` **[number][312]** The ID of the profession.
+  
+Returns **[Promise][310]&lt;[object][311]>**
+
+### getProfessionMedia
+  
+Returns media for a profession by ID.
+  
+#### Parameters  
+  
+-   `professionId` **[number][312]** The ID of the profession.
+  
+Returns **[Promise][310]&lt;[object][311]>**
+
+### getProfessionSkillTier 
+  
+Returns a skill tier for a profession by ID.
+  
+#### Parameters  
+  
+-   `professionId` **[number][312]** The ID of the profession.
+-   `skillTierId` **[number][312]** The ID of the skill tier.
+  
+Returns **[Promise][310]&lt;[object][311]>**  
+
+### getRecipe
+  
+Returns a recipe by ID.
+  
+#### Parameters  
+  
+-   `recipeId` **[number][312]** The ID of the recipe.
+  
+Returns **[Promise][310]&lt;[object][311]>**  
+
+### getRecipeMedia
+  
+Returns media for a recipe by ID.
+  
+#### Parameters  
+  
+-   `recipeId` **[number][312]** The ID of the recipe.
+  
+Returns **[Promise][310]&lt;[object][311]>**
   
 ### getPvpSeasonsIndex  
   
@@ -1697,3 +1760,17 @@ Returns **[Promise][310]&lt;[object][311]>**
 [312]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number  
   
 [313]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[315]: #getprofessionindex
+
+[316]: #getauctionhouse
+
+[317]: #getprofession
+
+[318]: #getprofessionmedia
+
+[319]: #getprofessionskilltier
+
+[320]: #getrecipe
+
+[321]: #getrecipemedia

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,8 +1017,8 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            console.log(error);
-            throw new Error(`WoW Game Data Error :: ${errorMessage}`);
+            console.log(`WoW Game Data Error :: ${errorMessage}`);
+            throw new Error(error);
         }
     }
 }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1021,6 +1021,8 @@ class WowGameData {
                 throw new Error(error.response.status);
             } else if (error.response.status === 403) {
                 throw new Error(error.response.status);
+            } else if (error.response.status === 500) {
+                throw new Error(error.response.status);
             } else {
                 console.error(error.response.statusText);
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -80,6 +80,23 @@ class WowGameData {
             this.staticNamespace
         );
     }
+    
+    /****************************
+     * Auction House API
+     ****************************/
+
+    /**
+     * Returns all active auctions for a connected realm.
+     *
+     * @param connectedRealmId The ID of the connected realm.
+     */
+    async getAuctionHouse(connectedRealmId: number): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`,
+            'Error fetching auction house data.',
+            this.staticNamespace
+        );
+    }
 
     /****************************
      * Azerite Essence API

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,8 +1017,9 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            console.log(`WoW Game Data Error :: ${errorMessage}`);
-            return error
+            console.error(`WoW Game Data Error :: ${errorMessage}`);
+            console.log(error.statusCode)
+            //throw new Error(error)
         }
     }
 }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,11 +1017,11 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            console.log(typeof error.response.status);
-            if (error.response.status == 304) {
-            } else if (error.response.status == 404) {
+            if (error.response.status === 304) {
 
-            } else if (error.response.status == 403) {
+            } else if (error.response.status === 404) {
+
+            } else if (error.response.status === 403) {
 
             } else {
                 console.error(error.response.statusText);

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -94,7 +94,7 @@ class WowGameData {
         return await this._handleApiCall(
             `${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`,
             'Error fetching auction house data.',
-            this.staticNamespace
+            this.dynamicNamespace
         );
     }
 

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,7 +1017,13 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+            console.log(typeof error.response.status);
+            if (error.response.status == 304) {
+            } else if (error.response.status == 404) {
+
+            } else if (error.response.status == 403) {
+
+            } else {
                 console.error(error.response.statusText);
             }
             throw new Error(`${errorMessage}`);

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -998,7 +998,7 @@ class WowGameData {
                     ...this.defaultAxiosParams
                 }});
             if (apiUrl.includes("auctions")) {
-                return {auctions: response.data.auctions, lastModified: response.headers}
+                return {auctions: response.data.auctions, lastModified: response.headers['last-modified']}
             } else {
                 return response.data;
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1016,13 +1016,7 @@ class WowGameData {
                 return response.data;
             }
         } catch (error) {
-            if (error.response.status === 304) {
-                throw new Error(error.response.status);
-            } else if (error.response.status === 404) {
-                throw new Error(error.response.status);
-            } else if (error.response.status === 403) {
-                throw new Error(error.response.status);
-            } else if (error.response.status === 500) {
+            if (~[304, 404, 403, 500].indexOf(error.response.status)) {
                 throw new Error(error.response.status);
             } else {
                 console.error(error.response.statusText);

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -997,7 +997,6 @@ class WowGameData {
             if (namespace.includes("static-")) {
                 const response = await this.axios.get(encodeURI(apiUrl), {
                     params: {
-                        timeout: 10000,
                         namespace: namespace,
                         ...this.defaultAxiosParams
                     },

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1010,6 +1010,7 @@ class WowGameData {
                     },
                     headers: {'If-Modified-Since': header},
                 });
+                if (response.data['statusCode']) response.data.statusCode = response.status;
                 if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
                 return response.data;
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,9 +1017,7 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            if (error.response.status === 304) return error.response.statusText;
-            if (error.response.status === 404) return error.response.statusText;
-            if (error.response.status === 403) return error.response.statusText;
+            if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403) console.log(error.response.statusText);
             throw new Error(`WoW Game Data Error :: ${errorMessage}`);
         }
     }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -997,7 +997,11 @@ class WowGameData {
                     namespace: namespace,
                     ...this.defaultAxiosParams
                 }});
-            return response.data;
+            if (apiUrl.includes("auctions")) {
+                return {auctions: response.data.auctions, lastModified: response.headers}
+            } else {
+                return response.data;
+            }
         } catch (error) {
             console.log(error);
             throw new Error(`WoW Game Data Error :: ${errorMessage}`);

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1015,11 +1015,11 @@ class WowGameData {
             }
         } catch (error) {
             if (error.response.status === 304) {
-
+                return error.response.status
             } else if (error.response.status === 404) {
-
+                return error.response.status
             } else if (error.response.status === 403) {
-
+                return error.response.status
             } else {
                 console.error(error.response.statusText);
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1018,7 +1018,7 @@ class WowGameData {
             }
         } catch (error) {
             console.error(`WoW Game Data Error :: ${errorMessage}`);
-            console.log(error)
+            console.log(error.response)
             //throw new Error(error)
         }
     }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1016,11 +1016,11 @@ class WowGameData {
             }
         } catch (error) {
             if (error.response.status === 304) {
-                return error.response.status
+                throw new Error(error.response.status);
             } else if (error.response.status === 404) {
-                return error.response.status
+                throw new Error(error.response.status);
             } else if (error.response.status === 403) {
-                return error.response.status
+                throw new Error(error.response.status);
             } else {
                 console.error(error.response.statusText);
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1013,6 +1013,7 @@ class WowGameData {
                 if (apiUrl.includes("auctions")) {
                     return {auctions: response.data.auctions, lastModified: response.headers['last-modified']}
                 } else {
+                    if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
                     return response.data;
                 }
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1018,7 +1018,7 @@ class WowGameData {
             }
         } catch (error) {
             console.error(`WoW Game Data Error :: ${errorMessage}`);
-            console.log(error.statusCode)
+            console.log(error)
             //throw new Error(error)
         }
     }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,10 +1017,10 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            console.error(`WoW Game Data Error :: ${errorMessage}`);
             if (error.response.status === 304) return error.response.statusText;
             if (error.response.status === 404) return error.response.statusText;
             if (error.response.status === 403) return error.response.statusText;
+            throw new Error(`WoW Game Data Error :: ${errorMessage}`);
         }
     }
 }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1017,7 +1017,9 @@ class WowGameData {
                 }
             }
         } catch (error) {
-            if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403) console.log(error.response.statusText);
+            if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+                console.error(error.response.statusText);
+            }
             throw new Error(`${errorMessage}`);
         }
     }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1010,7 +1010,7 @@ class WowGameData {
                     },
                     headers: {'If-Modified-Since': header},
                 });
-                if (response.data['statusCode']) response.data.statusCode = response.status;
+                if (response.status) response.data.statusCode = response.status;
                 if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
                 return response.data;
             }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -94,7 +94,7 @@ class WowGameData {
     async getAuctionHouse(connectedRealmId: number, header: string = ''): Promise<object> {
         return await this._handleApiCall(
             `${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`,
-            'Error fetching auction house data.',
+            `Error fetching auction house data from ${connectedRealmId}`,
             this.dynamicNamespace,
             header
         );

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1010,12 +1010,8 @@ class WowGameData {
                     },
                     headers: {'If-Modified-Since': header},
                 });
-                if (apiUrl.includes("auctions")) {
-                    return {auctions: response.data.auctions, lastModified: response.headers['last-modified']}
-                } else {
-                    if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
-                    return response.data;
-                }
+                if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
+                return response.data;
             }
         } catch (error) {
             if (error.response.status === 304) {

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -997,6 +997,7 @@ class WowGameData {
             if (namespace.includes("static-")) {
                 const response = await this.axios.get(encodeURI(apiUrl), {
                     params: {
+                        timeout: 10000,
                         namespace: namespace,
                         ...this.defaultAxiosParams
                     },
@@ -1005,6 +1006,7 @@ class WowGameData {
             } else {
                 const response = await this.axios.get(encodeURI(apiUrl), {
                     params: {
+                        timeout: 10000,
                         namespace: namespace,
                         ...this.defaultAxiosParams
                     },

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1018,8 +1018,9 @@ class WowGameData {
             }
         } catch (error) {
             console.error(`WoW Game Data Error :: ${errorMessage}`);
-            console.log(error.response)
-            //throw new Error(error)
+            if (error.response.status === 304) return error.response.statusText;
+            if (error.response.status === 404) return error.response.statusText;
+            if (error.response.status === 403) return error.response.statusText;
         }
     }
 }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1018,7 +1018,7 @@ class WowGameData {
             }
         } catch (error) {
             console.log(`WoW Game Data Error :: ${errorMessage}`);
-            throw new Error(error);
+            return error
         }
     }
 }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -729,6 +729,76 @@ class WowGameData {
     }
 
     /****************************
+     * Professions API
+     ****************************/
+
+    /**
+     * Returns an index of professions.
+     */
+    async getProfessionsIndex(): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/profession/index`,
+            'Error fetching professions index.',
+            this.staticNamespace
+        );
+    }
+
+    /**
+     * Returns a profession by ID
+     */
+    async getProfession(professionId: number): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/profession/${professionId}`,
+            'Error fetching professions.',
+            this.staticNamespace
+        );
+    }
+
+    /**
+     * Returns media for a profession by ID.
+     */
+    async getProfessionMedia (professionId: number): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/media/profession/${professionId}`,
+            'Error fetching specified profession media.',
+            this.staticNamespace
+        );
+    }
+
+    /**
+     * Returns a skill tier for a profession by ID.
+     */
+    async getProfessionSkillTier (professionId: number, skillTierId: number): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/profession/${professionId}/skill-tier/${skillTierId}`,
+            'Error fetching skill tier profession.',
+            this.staticNamespace
+        );
+    }
+
+    /**
+     * Returns a recipe by ID.
+     */
+    async getRecipe (recipeId: number): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/recipe/${recipeId} `,
+            'Error fetching recipe by ID.',
+            this.staticNamespace
+        );
+    }
+
+    /**
+     * Returns media for a recipe by ID.
+     */
+    async getRecipeMedia  (recipeId: number): Promise<object> {
+        return await this._handleApiCall(
+            `${this.gameBaseUrlPath}/media/recipe/${recipeId}`,
+            'Error fetching recipe media by ID.',
+            this.staticNamespace
+        );
+    }
+
+    /****************************
      * PvP Season API
      ****************************/
 

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -1018,7 +1018,7 @@ class WowGameData {
             }
         } catch (error) {
             if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403) console.log(error.response.statusText);
-            throw new Error(`WoW Game Data Error :: ${errorMessage}`);
+            throw new Error(`${errorMessage}`);
         }
     }
 }

--- a/src/wow/gameData.ts
+++ b/src/wow/gameData.ts
@@ -91,7 +91,7 @@ class WowGameData {
      * @param connectedRealmId The ID of the connected realm.
      * @param header If-Modified-Since request HTTP header
      */
-    async getAuctionHouse(connectedRealmId: number, header: string): Promise<object> {
+    async getAuctionHouse(connectedRealmId: number, header: string = ''): Promise<object> {
         return await this._handleApiCall(
             `${this.gameBaseUrlPath}/connected-realm/${connectedRealmId}/auctions`,
             'Error fetching auction house data.',

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -310,7 +310,9 @@ class WowProfileData {
                 }});
             return response.data;
         } catch (error) {
-            if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403) console.log(error.response.statusText);
+            if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+                console.error(error.response.statusText);
+            }
             throw new Error(`${errorMessage}`);
         }
     }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -308,6 +308,7 @@ class WowProfileData {
                     namespace: this.namespace,
                     ...this.defaultAxiosParams
                 }});
+            if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
             return response.data;
         } catch (error) {
             if (error.response.status === 304) {

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -311,7 +311,7 @@ class WowProfileData {
             return response.data;
         } catch (error) {
             if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403) console.log(error.response.statusText);
-            throw new Error(`WoW Game Data Error :: ${errorMessage}`);
+            throw new Error(`${errorMessage}`);
         }
     }
 }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -318,6 +318,8 @@ class WowProfileData {
                 throw new Error(error.response.status);
             } else if (error.response.status === 403) {
                 throw new Error(error.response.status);
+            } else if (error.response.status === 500) {
+                throw new Error(error.response.status);
             } else {
                 console.error(error.response.statusText);
             }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -310,11 +310,11 @@ class WowProfileData {
                 }});
             return response.data;
         } catch (error) {
-            console.log(typeof error.response.status);
-            if (error.response.status == 304) {
-            } else if (error.response.status == 404) {
+            if (error.response.status === 304) {
 
-            } else if (error.response.status == 403) {
+            } else if (error.response.status === 404) {
+
+            } else if (error.response.status === 403) {
 
             } else {
                 console.error(error.response.statusText);

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -312,13 +312,7 @@ class WowProfileData {
             if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
             return response.data;
         } catch (error) {
-            if (error.response.status === 304) {
-                throw new Error(error.response.status);
-            } else if (error.response.status === 404) {
-                throw new Error(error.response.status);
-            } else if (error.response.status === 403) {
-                throw new Error(error.response.status);
-            } else if (error.response.status === 500) {
+            if (~[304, 404, 403, 500].indexOf(error.response.status)) {
                 throw new Error(error.response.status);
             } else {
                 console.error(error.response.statusText);

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -310,8 +310,10 @@ class WowProfileData {
                 }});
             return response.data;
         } catch (error) {
-            console.log(error);
-            throw new Error(`WoW Profile Error :: ${errorMessage}`);
+            if (error.response.status === 304) console.log(error.response.statusText);
+            if (error.response.status === 404) console.log(error.response.statusText);
+            if (error.response.status === 403) console.log(error.response.statusText);
+            throw new Error(`WoW Game Data Error :: ${errorMessage}`);
         }
     }
 }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -310,9 +310,7 @@ class WowProfileData {
                 }});
             return response.data;
         } catch (error) {
-            if (error.response.status === 304) console.log(error.response.statusText);
-            if (error.response.status === 404) console.log(error.response.statusText);
-            if (error.response.status === 403) console.log(error.response.statusText);
+            if (error.response.status !== 304 || error.response.status !== 404 || error.response.status !== 403) console.log(error.response.statusText);
             throw new Error(`WoW Game Data Error :: ${errorMessage}`);
         }
     }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -308,7 +308,7 @@ class WowProfileData {
                     namespace: this.namespace,
                     ...this.defaultAxiosParams
                 }});
-            if (response.data['statusCode']) response.data.statusCode = response.status;
+            if (response.status) response.data.statusCode = response.status;
             if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
             return response.data;
         } catch (error) {

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -308,6 +308,7 @@ class WowProfileData {
                     namespace: this.namespace,
                     ...this.defaultAxiosParams
                 }});
+            if (response.data['statusCode']) response.data.statusCode = response.status;
             if (response.headers['last-modified']) response.data.lastModified = response.headers['last-modified'];
             return response.data;
         } catch (error) {

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -312,11 +312,11 @@ class WowProfileData {
             return response.data;
         } catch (error) {
             if (error.response.status === 304) {
-
+                return error.response.status
             } else if (error.response.status === 404) {
-
+                return error.response.status
             } else if (error.response.status === 403) {
-
+                return error.response.status
             } else {
                 console.error(error.response.statusText);
             }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -310,7 +310,13 @@ class WowProfileData {
                 }});
             return response.data;
         } catch (error) {
-            if (error.response.status != 304 || error.response.status != 404 || error.response.status != 403) {
+            console.log(typeof error.response.status);
+            if (error.response.status == 304) {
+            } else if (error.response.status == 404) {
+
+            } else if (error.response.status == 403) {
+
+            } else {
                 console.error(error.response.statusText);
             }
             throw new Error(`${errorMessage}`);

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -305,6 +305,7 @@ class WowProfileData {
         try {
             const response = await this.axios.get(encodeURI(apiUrl), {
                 params: {
+                    timeout: 10000,
                     namespace: this.namespace,
                     ...this.defaultAxiosParams
                 }});

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -313,11 +313,11 @@ class WowProfileData {
             return response.data;
         } catch (error) {
             if (error.response.status === 304) {
-                return error.response.status
+                throw new Error(error.response.status);
             } else if (error.response.status === 404) {
-                return error.response.status
+                throw new Error(error.response.status);
             } else if (error.response.status === 403) {
-                return error.response.status
+                throw new Error(error.response.status);
             } else {
                 console.error(error.response.statusText);
             }

--- a/src/wow/profileData.ts
+++ b/src/wow/profileData.ts
@@ -305,7 +305,6 @@ class WowProfileData {
         try {
             const response = await this.axios.get(encodeURI(apiUrl), {
                 params: {
-                    timeout: 10000,
                     namespace: this.namespace,
                     ...this.defaultAxiosParams
                 }});


### PR DESCRIPTION
This little patch fixes the following problems:

- added `providedToken` to `bnw.init(_id, secret, token, region, locale)` stage. Now you can manually insert token, without requesting if before every use.
- added timeout: 10s for all requests
- [added all Recipe and Professions endpoint](https://us.forums.blizzard.com/en/blizzard/t/world-of-warcraft-api-patch-notes-20200414/5680)
- extends AuctionsHouse method with *optional* header (string) argument ([more info at Readme.md](https://github.com/AlexZeDim/battlenet-api-wrapper/tree/master/src/wow#getauctionhouse))
- extends error handling for 304, 400, 403, 404 errors (now return `statusCodes`, instead of useless `statusText`
- add to `response` custom param (`lastModified`) (only if, header exists) which allows you to use `If-modified` logic ([learn more at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified))